### PR TITLE
threads, objects and logging

### DIFF
--- a/BaseCollector.py
+++ b/BaseCollector.py
@@ -21,7 +21,7 @@ class BaseCollector(ABC):
         threads = list()
         for vc in self.all_vcenters:
             vc.login()
-            if not vc.session_id:
+            if not vc.con.session_id:
                 LOG.warning(f"Skipping {vc.name}, did not receive any session id")
                 continue
             thread = Thread(target=self.fetch_collector_data, args=(vc,))

--- a/BaseCollector.py
+++ b/BaseCollector.py
@@ -1,16 +1,65 @@
 from abc import ABC, abstractmethod
+from threading import Thread
+import time
 import yaml
+import logging
+
+LOG = logging.getLogger('vcsa-exporter')
+
 
 class BaseCollector(ABC):
+    def __init__(self, all_vcenters):
+        self.metrics = list()
+        self.timeout = 60
+        self.all_vcenters = all_vcenters
+
     @abstractmethod
     def describe(self):
         pass
 
-    @abstractmethod
     def collect(self):
+        threads = list()
+        for vc in self.all_vcenters:
+            vc.login()
+            if not vc.session_id:
+                LOG.warning(f"Skipping {vc.name}, did not receive any session id")
+                continue
+            thread = Thread(target=self.fetch_collector_data, args=(vc,))
+            thread.start()
+            threads.append((thread, vc.name))
+
+        timeout = self.timeout
+        start_time = time.time()
+        current_time = start_time
+        joined_threads = dict()
+        while current_time <= (start_time + timeout):
+            for t in threads:
+                if not t[0].is_alive():
+                    t[0].join()
+                    if t[0] not in joined_threads:
+                        joined_threads.setdefault(t[1], round(time.time() - start_time))
+            if len(joined_threads.keys()) >= len(threads):
+                break
+            time.sleep(1)
+            current_time = time.time()
+        else:
+            still_running = [t for t in threads if t[0].is_alive()]
+            for running_thread in still_running:
+                LOG.info(f"Timeout {timeout}s reached for fetching {running_thread[1]}")
+                running_thread[0].join(0)
+        for vc in joined_threads:
+            # self.vrops_collection_times[vrops] = joined_threads[vrops]
+            LOG.info(f"Fetched {vc} in {joined_threads[vc]}s")
+
+        for metric in self.metrics:
+            yield metric
+
+    @abstractmethod
+    def fetch_collector_data(self, vc):
         pass
 
-    def read_rest_yaml(self):
+    @staticmethod
+    def read_rest_yaml():
         with open('./rest.yaml') as yaml_file:
             rest_yaml = yaml.safe_load(yaml_file)
         return rest_yaml

--- a/collectors/LoggingCollector.py
+++ b/collectors/LoggingCollector.py
@@ -26,7 +26,7 @@ class LoggingCollector(BaseCollector):
         rest_yaml = BaseCollector.read_rest_yaml()
         api_target = rest_yaml['logging']['api_target']
         action = rest_yaml['logging']['action']
-        fetched_data = Connection.post_request(vc.name, api_target, action, vc.session_id)
+        fetched_data = vc.con.post_request(api_target, action)
         vc.logout()
         if not fetched_data:
             LOG.debug(f"Skipping vc {vc.name} fetched data did not return anything")

--- a/collectors/LoggingCollector.py
+++ b/collectors/LoggingCollector.py
@@ -7,8 +7,8 @@ LOG = logging.getLogger('vcsa-exporter')
 
 
 class LoggingCollector(BaseCollector):
-    def __init__(self, vcenter):
-        self.vcenter = vcenter
+    def __init__(self, all_vcenters):
+        super().__init__(all_vcenters)
         self.connection_states = {
             'UP': 1,
             'UNKNOWN': 2,
@@ -18,29 +18,25 @@ class LoggingCollector(BaseCollector):
     def describe(self):
         yield GaugeMetricFamily('vcsa_logging_status', 'Checks the log forwarding of vCSA.')
 
-    def collect(self):
-        for vc in self.vcenter.vcenter_list:
-            g = GaugeMetricFamily('vcsa_logging_status',
-                                  'Checks the log forwarding of vCSA. Down: 0 Up: 1 Unknown: 2',
-                                  labels=['loghost', 'vccluster'])
+    def fetch_collector_data(self, vc):
+        g = GaugeMetricFamily('vcsa_logging_status',
+                              'Checks the log forwarding of vCSA. Down: 0 Up: 1 Unknown: 2',
+                              labels=['loghost', 'vccluster'])
 
-            rest_yaml = self.read_rest_yaml()
-            api_target = rest_yaml['logging']['api_target']
-            action = rest_yaml['logging']['action']
-            session_id = Connection.login(vc, self.vcenter.user, self.vcenter.generate_pw(vc))
-            if not session_id:
-                LOG.warning(f"skipping vc {vc} login not possible")
-                continue
-            fetched_data = Connection.post_request(vc, api_target, action, session_id)
-            Connection.logout(vc, session_id)
-            if not fetched_data:
-                LOG.debug(f"skipping vc {vc} fetched data did not return anything")
-                continue
+        rest_yaml = BaseCollector.read_rest_yaml()
+        api_target = rest_yaml['logging']['api_target']
+        action = rest_yaml['logging']['action']
+        # session_id = Connection.login(vc, self.vcenter.user, self.vcenter.generate_pw(vc))
+        fetched_data = Connection.post_request(vc.name, api_target, action, vc.session_id)
+        # Connection.logout(vc, session_id)
+        if not fetched_data:
+            LOG.debug(f"Skipping vc {vc.name} fetched data did not return anything")
+            return
 
-            for loghost in fetched_data['value']:
-                loghost_name = loghost['hostname']
-                state = loghost['state']
-                g.add_metric(labels=[loghost_name, vc],
-                             value=self.connection_states[state])
-
-            yield g
+        for loghost in fetched_data['value']:
+            loghost_name = loghost['hostname']
+            state = loghost['state']
+            g.add_metric(labels=[loghost_name, vc.name],
+                         value=self.connection_states[state])
+        vc.logout()
+        self.metrics.append(g)

--- a/collectors/LoggingCollector.py
+++ b/collectors/LoggingCollector.py
@@ -26,9 +26,8 @@ class LoggingCollector(BaseCollector):
         rest_yaml = BaseCollector.read_rest_yaml()
         api_target = rest_yaml['logging']['api_target']
         action = rest_yaml['logging']['action']
-        # session_id = Connection.login(vc, self.vcenter.user, self.vcenter.generate_pw(vc))
         fetched_data = Connection.post_request(vc.name, api_target, action, vc.session_id)
-        # Connection.logout(vc, session_id)
+        vc.logout()
         if not fetched_data:
             LOG.debug(f"Skipping vc {vc.name} fetched data did not return anything")
             return
@@ -38,5 +37,4 @@ class LoggingCollector(BaseCollector):
             state = loghost['state']
             g.add_metric(labels=[loghost_name, vc.name],
                          value=self.connection_states[state])
-        vc.logout()
         self.metrics.append(g)

--- a/collectors/LoggingCollector.py
+++ b/collectors/LoggingCollector.py
@@ -1,6 +1,9 @@
 from prometheus_client.core import GaugeMetricFamily
 from BaseCollector import BaseCollector
 from modules.Connection import Connection
+import logging
+
+LOG = logging.getLogger('vcsa-exporter')
 
 
 class LoggingCollector(BaseCollector):
@@ -26,12 +29,12 @@ class LoggingCollector(BaseCollector):
             action = rest_yaml['logging']['action']
             session_id = Connection.login(vc, self.vcenter.user, self.vcenter.generate_pw(vc))
             if not session_id:
-                print("skipping vc", vc, ", login not possible")
+                LOG.warning(f"skipping vc {vc} login not possible")
                 continue
             fetched_data = Connection.post_request(vc, api_target, action, session_id)
             Connection.logout(vc, session_id)
             if not fetched_data:
-                print("skipping vc", vc, "fetched data did not return anything")
+                LOG.debug(f"skipping vc {vc} fetched data did not return anything")
                 continue
 
             for loghost in fetched_data['value']:

--- a/collectors/VmonCollector.py
+++ b/collectors/VmonCollector.py
@@ -28,12 +28,11 @@ class VmonCollector(BaseCollector):
 
         api_target = rest_yaml['vmonservice']['api_target']
 
-        # session_id = Connection.login(vc, self.vcenter.user, self.vcenter.generate_pw(vc))
         if not vc.session_id:
             LOG.warning(f"skipping vc {vc.name} login not possible")
             return
         fetched_data = Connection.get_request(vc.name, api_target, vc.session_id)
-        # Connection.logout(vc, session_id)
+        vc.logout()
         if not fetched_data:
             LOG.warning(f"skipping vc {vc.name} fetched data did not return anything")
             return

--- a/collectors/VmonCollector.py
+++ b/collectors/VmonCollector.py
@@ -7,8 +7,8 @@ LOG = logging.getLogger('vcsa-exporter')
 
 
 class VmonCollector(BaseCollector):
-    def __init__(self, vcenter):
-        self.vcenter = vcenter
+    def __init__(self, all_vcenters):
+        super().__init__(all_vcenters)
         self.health_states = {
             "HEALTHY": 3,
             "HEALTHY_WITH_WARNINGS": 2,
@@ -19,35 +19,33 @@ class VmonCollector(BaseCollector):
     def describe(self):
         yield GaugeMetricFamily('vcsa_service_status', 'Health Status of vCSA Services')
 
-    def collect(self):
-        for vc in self.vcenter.vcenter_list:
-            g = GaugeMetricFamily('vcsa_service_status',
-                                  'Status of vCSA Services',
-                                  labels=['service', 'vccluster'])
+    def fetch_collector_data(self, vc):
+        g = GaugeMetricFamily('vcsa_service_status',
+                              'Status of vCSA Services',
+                              labels=['service', 'vccluster'])
 
-            rest_yaml = self.read_rest_yaml()
+        rest_yaml = BaseCollector.read_rest_yaml()
 
-            api_target = rest_yaml['vmonservice']['api_target']
+        api_target = rest_yaml['vmonservice']['api_target']
 
-            # TODO: move session handling to base class. implement reuse of sessions
-            session_id = Connection.login(vc, self.vcenter.user, self.vcenter.generate_pw(vc))
-            if not session_id:
-                LOG.warning(f"skipping vc {vc} login not possible")
-                continue
-            fetched_data = Connection.get_request(vc, api_target, session_id)
-            Connection.logout(vc, session_id)
-            if not fetched_data:
-                LOG.warning(f"skipping vc {vc} fetched data did not return anything")
-                continue
+        # session_id = Connection.login(vc, self.vcenter.user, self.vcenter.generate_pw(vc))
+        if not vc.session_id:
+            LOG.warning(f"skipping vc {vc.name} login not possible")
+            return
+        fetched_data = Connection.get_request(vc.name, api_target, vc.session_id)
+        # Connection.logout(vc, session_id)
+        if not fetched_data:
+            LOG.warning(f"skipping vc {vc.name} fetched data did not return anything")
+            return
 
-            for service in fetched_data['value']:
-                service_name = service['key']
-                state = service['value']['state']
-                if state == "STOPPED":
-                    service_health = "STOPPED"
-                else:
-                    service_health = service['value']['health']
+        for service in fetched_data['value']:
+            service_name = service['key']
+            state = service['value']['state']
+            if state == "STOPPED":
+                service_health = "STOPPED"
+            else:
+                service_health = service['value']['health']
 
-                g.add_metric(labels=[service_name, vc], value=self.health_states[service_health])
-
-            yield g
+            g.add_metric(labels=[service_name, vc.name], value=self.health_states[service_health])
+        vc.logout()
+        self.metrics.append(g)

--- a/collectors/VmonCollector.py
+++ b/collectors/VmonCollector.py
@@ -28,10 +28,7 @@ class VmonCollector(BaseCollector):
 
         api_target = rest_yaml['vmonservice']['api_target']
 
-        if not vc.session_id:
-            LOG.warning(f"skipping vc {vc.name} login not possible")
-            return
-        fetched_data = Connection.get_request(vc.name, api_target, vc.session_id)
+        fetched_data = vc.con.get_request(api_target)
         vc.logout()
         if not fetched_data:
             LOG.warning(f"skipping vc {vc.name} fetched data did not return anything")
@@ -46,5 +43,4 @@ class VmonCollector(BaseCollector):
                 service_health = service['value']['health']
 
             g.add_metric(labels=[service_name, vc.name], value=self.health_states[service_health])
-        vc.logout()
         self.metrics.append(g)

--- a/collectors/VmonCollector.py
+++ b/collectors/VmonCollector.py
@@ -1,6 +1,9 @@
 from prometheus_client.core import GaugeMetricFamily
 from BaseCollector import BaseCollector
 from modules.Connection import Connection
+import logging
+
+LOG = logging.getLogger('vcsa-exporter')
 
 
 class VmonCollector(BaseCollector):
@@ -29,15 +32,14 @@ class VmonCollector(BaseCollector):
             # TODO: move session handling to base class. implement reuse of sessions
             session_id = Connection.login(vc, self.vcenter.user, self.vcenter.generate_pw(vc))
             if not session_id:
-                print("skipping vc", vc, ", login not possible")
+                LOG.warning(f"skipping vc {vc} login not possible")
                 continue
             fetched_data = Connection.get_request(vc, api_target, session_id)
             Connection.logout(vc, session_id)
             if not fetched_data:
-                print("skipping vc", vc, "fetched data did not return anything")
+                LOG.warning(f"skipping vc {vc} fetched data did not return anything")
                 continue
 
-            services = dict()
             for service in fetched_data['value']:
                 service_name = service['key']
                 state = service['value']['state']

--- a/exporter.py
+++ b/exporter.py
@@ -55,8 +55,5 @@ def run_prometheus_server(port, vcenter):
 if __name__ == '__main__':
     logger = logging.getLogger('vcsa-exporter')
     options = parse_params(logger)
-    all_vcenters = list()
-    for vcenter in Vcenter.get_vcs_from_atlas(options.atlas):
-        all_vcenters.append(Vcenter(vcenter, options.master_password,
-                                    options.user, password=options.password))
+all_vcenters = [Vcenter(vcenter, options.master_password, options.user, password=options.password) for vcenter in Vcenter.get_vcs_from_atlas(options.atlas)]
     run_prometheus_server(options.port, all_vcenters)

--- a/exporter.py
+++ b/exporter.py
@@ -55,5 +55,6 @@ def run_prometheus_server(port, vcenter):
 if __name__ == '__main__':
     logger = logging.getLogger('vcsa-exporter')
     options = parse_params(logger)
-all_vcenters = [Vcenter(vcenter, options.master_password, options.user, password=options.password) for vcenter in Vcenter.get_vcs_from_atlas(options.atlas)]
+    all_vcenters = [Vcenter(vcenter, options.master_password, options.user, password=options.password)
+                    for vcenter in Vcenter.get_vcs_from_atlas(options.atlas)]
     run_prometheus_server(options.port, all_vcenters)

--- a/exporter.py
+++ b/exporter.py
@@ -57,6 +57,6 @@ if __name__ == '__main__':
     options = parse_params(logger)
     all_vcenters = list()
     for vcenter in Vcenter.get_vcs_from_atlas(options.atlas):
-        all_vcenters.append(Vcenter(vcenter, options.atlas, options.master_password,
+        all_vcenters.append(Vcenter(vcenter, options.master_password,
                                     options.user, password=options.password))
     run_prometheus_server(options.port, all_vcenters)

--- a/modules/Connection.py
+++ b/modules/Connection.py
@@ -1,7 +1,6 @@
 from urllib3 import disable_warnings
 from urllib3 import exceptions
 import requests
-import os
 import logging
 
 LOG = logging.getLogger('vcsa-exporter')
@@ -21,6 +20,7 @@ class Connection:
             return response.json()['value']
         else:
             LOG.warning(f"Problem logging into {target}: {response.text}")
+            return False
 
     def get_request(target, key, session_id):
         disable_warnings(exceptions.InsecureRequestWarning)

--- a/modules/Connection.py
+++ b/modules/Connection.py
@@ -1,74 +1,71 @@
 from urllib3 import disable_warnings
 from urllib3 import exceptions
 import requests
-import json
 import os
+import logging
+
+LOG = logging.getLogger('vcsa-exporter')
 
 
 class Connection:
     def login(target, user, password):
         disable_warnings(exceptions.InsecureRequestWarning)
-        if os.environ['DEBUG'] == "1":
-            print("login", target)
-        url = "https://" + target + "/rest/com/vmware/cis/session" 
+        LOG.debug(f"login {target}")
+        url = "https://" + target + "/rest/com/vmware/cis/session"
         try:
             response = requests.post(url, auth=(user, password), verify=False)
         except Exception as e:
-            print("Problem connecting to", target, "Error:", str(e))
+            LOG.error(f"Problem connecting to {target} Error: {str(e)}")
             return False
-        
         if response.status_code == 200:
             return response.json()['value']
         else:
-            print("Problem logging into", target, ":", response.text)
-    
+            LOG.warning(f"Problem logging into {target}: {response.text}")
+
     def get_request(target, key, session_id):
         disable_warnings(exceptions.InsecureRequestWarning)
-        if os.environ['DEBUG'] == "1":
-            print("request",target, key)
-        url = "https://" + target + "/rest/" + key 
+        LOG.debug(f"request {target}, {key}")
+        url = "https://" + target + "/rest/" + key
         try:
             response = requests.get(url, verify=False,
                                     headers={"vmware-api-session-id": session_id})
         except Exception as e:
-            print("Problem handling", key, "for", target, ":", str(e))
+            LOG.error(f"Problem handling {key} for {target}: {str(e)}")
             return False
         if response.status_code == 200:
             return response.json()
         else:
-            print("Problem with get return of", target, ":", response.text)
+            LOG.warning(f"Problem with get return of {target}: {response.text}")
             return False
 
     def post_request(target, key, data, session_id):
         disable_warnings(exceptions.InsecureRequestWarning)
-        if os.environ['DEBUG'] == "1":
-            print("request", target, key)
+        LOG.debug(f"request {target} {key}")
         url = "https://" + target + "/rest/" + key + '?' + data
         try:
             response = requests.post(url, verify=False,
-                                    headers={"vmware-api-session-id": session_id})
+                                     headers={"vmware-api-session-id": session_id})
         except Exception as e:
-            print("Problem handling", key, "for", target, ":", str(e))
+            LOG.error(f"Problem handling {key} for {target}: {str(e)}")
             return False
         if response.status_code == 200:
             return response.json()
         else:
-            print("Problem with post return of", target, ":", response.text)
+            LOG.warning(f"Problem with post return of {target}: {response.text}")
             return False
 
     # going to be used until reuse of session_id is in place
     def logout(target, session_id):
         disable_warnings(exceptions.InsecureRequestWarning)
-        if os.environ['DEBUG'] == "1":
-            print("logout",target)
+        LOG.debug(f"logout {target}")
         url = "https://" + target + "/rest/com/vmware/cis/session"
         try:
             response = requests.delete(url, verify=False,
-                                    headers={"vmware-api-session-id": session_id})
+                                       headers={"vmware-api-session-id": session_id})
         except Exception as e:
-            print("Problem deleting session for", target, ":", str(e))
+            LOG.error(f"Problem deleting session for {target}: {str(e)}")
             return False
         if response.status_code == 200:
             return
         else:
-            print("Problem with getting return of", target, ":", response.text)
+            LOG.warning(f"Problem with getting return of {target}: {response.text}")

--- a/modules/Connection.py
+++ b/modules/Connection.py
@@ -7,65 +7,71 @@ LOG = logging.getLogger('vcsa-exporter')
 
 
 class Connection:
-    def login(target, user, password):
+    def __init__(self, vcenter):
+        self.target = vcenter.name
+        self.user = vcenter.user
+        self.pw = vcenter.pw
+        self.session_id = None
+
+    def login(self):
         disable_warnings(exceptions.InsecureRequestWarning)
-        LOG.debug(f"login {target}")
-        url = "https://" + target + "/rest/com/vmware/cis/session"
+        LOG.debug(f"login {self.target}")
+        url = "https://" + self.target + "/rest/com/vmware/cis/session"
         try:
-            response = requests.post(url, auth=(user, password), verify=False)
+            response = requests.post(url, auth=(self.user, self.pw), verify=False)
         except Exception as e:
-            LOG.error(f"Problem connecting to {target} Error: {str(e)}")
+            LOG.error(f"Problem connecting to {self.target} Error: {str(e)}")
             return False
         if response.status_code == 200:
-            return response.json()['value']
+            self.session_id = response.json()['value']
+            LOG.debug(f"login session id {self.target} {self.session_id}")
         else:
-            LOG.warning(f"Problem logging into {target}: {response.text}")
+            LOG.warning(f"Problem logging into {self.target}: {response.text}")
             return False
 
-    def get_request(target, key, session_id):
+    def get_request(self, key):
         disable_warnings(exceptions.InsecureRequestWarning)
-        LOG.debug(f"request {target}, {key}")
-        url = "https://" + target + "/rest/" + key
+        LOG.debug(f"request {self.target}, {key}")
+        url = "https://" + self.target + "/rest/" + key
         try:
             response = requests.get(url, verify=False,
-                                    headers={"vmware-api-session-id": session_id})
+                                    headers={"vmware-api-session-id": self.session_id})
         except Exception as e:
-            LOG.error(f"Problem handling {key} for {target}: {str(e)}")
+            LOG.error(f"Problem handling {key} for {self.target}: {str(e)}")
             return False
         if response.status_code == 200:
             return response.json()
         else:
-            LOG.warning(f"Problem with get return of {target}: {response.text}")
+            LOG.warning(f"Problem with get return of {self.target}: {response.text}")
             return False
 
-    def post_request(target, key, data, session_id):
+    def post_request(self, key, data):
         disable_warnings(exceptions.InsecureRequestWarning)
-        LOG.debug(f"request {target} {key}")
-        url = "https://" + target + "/rest/" + key + '?' + data
+        LOG.debug(f"request {self.target} {key}")
+        url = "https://" + self.target + "/rest/" + key + '?' + data
         try:
             response = requests.post(url, verify=False,
-                                     headers={"vmware-api-session-id": session_id})
+                                     headers={"vmware-api-session-id": self.session_id})
         except Exception as e:
-            LOG.error(f"Problem handling {key} for {target}: {str(e)}")
+            LOG.error(f"Problem handling {key} for {self.target}: {str(e)}")
             return False
         if response.status_code == 200:
             return response.json()
         else:
-            LOG.warning(f"Problem with post return of {target}: {response.text}")
+            LOG.warning(f"Problem with post return of {self.target}: {response.text}")
             return False
 
-    # going to be used until reuse of session_id is in place
-    def logout(target, session_id):
+    def logout(self):
         disable_warnings(exceptions.InsecureRequestWarning)
-        LOG.debug(f"logout {target}")
-        url = "https://" + target + "/rest/com/vmware/cis/session"
+        LOG.debug(f"Logout {self.target} {self.session_id}")
+        url = "https://" + self.target + "/rest/com/vmware/cis/session"
         try:
             response = requests.delete(url, verify=False,
-                                       headers={"vmware-api-session-id": session_id})
+                                       headers={"vmware-api-session-id": self.session_id})
         except Exception as e:
-            LOG.error(f"Problem deleting session for {target}: {str(e)}")
+            LOG.error(f"Problem deleting session for {self.target}: {str(e)}")
             return False
         if response.status_code == 200:
             return
         else:
-            LOG.warning(f"Problem with getting return of {target}: {response.text}")
+            LOG.warning(f"Problem logging out, getting return of {self.target} {self.session_id}: {response.text}")

--- a/modules/Connection.py
+++ b/modules/Connection.py
@@ -48,7 +48,9 @@ class Connection:
     def post_request(self, key, data):
         disable_warnings(exceptions.InsecureRequestWarning)
         LOG.debug(f"request {self.target} {key}")
-        url = "https://" + self.target + "/rest/" + key + '?' + data
+        url = "https://" + self.target + "/rest/" + key
+        try:
+           response = requests.post(url, verify=False, data=data, headers={"vmware-api-session-id": session_id})	            
         try:
             response = requests.post(url, verify=False,
                                      headers={"vmware-api-session-id": self.session_id})

--- a/modules/Connection.py
+++ b/modules/Connection.py
@@ -2,6 +2,7 @@ from urllib3 import disable_warnings
 from urllib3 import exceptions
 import requests
 import logging
+import json
 
 LOG = logging.getLogger('vcsa-exporter')
 
@@ -16,7 +17,7 @@ class Connection:
     def login(self):
         disable_warnings(exceptions.InsecureRequestWarning)
         LOG.debug(f"login {self.target}")
-        url = "https://" + self.target + "/rest/com/vmware/cis/session"
+        url = f"https://{self.target}/rest/com/vmware/cis/session"
         try:
             response = requests.post(url, auth=(self.user, self.pw), verify=False)
         except Exception as e:
@@ -32,7 +33,7 @@ class Connection:
     def get_request(self, key):
         disable_warnings(exceptions.InsecureRequestWarning)
         LOG.debug(f"request {self.target}, {key}")
-        url = "https://" + self.target + "/rest/" + key
+        url = f"https://{self.target}/rest/{key}"
         try:
             response = requests.get(url, verify=False,
                                     headers={"vmware-api-session-id": self.session_id})
@@ -48,9 +49,7 @@ class Connection:
     def post_request(self, key, data):
         disable_warnings(exceptions.InsecureRequestWarning)
         LOG.debug(f"request {self.target} {key}")
-        url = "https://" + self.target + "/rest/" + key
-        try:
-           response = requests.post(url, verify=False, data=data, headers={"vmware-api-session-id": session_id})	            
+        url = f"https://{self.target}/rest/{key}?{data}"
         try:
             response = requests.post(url, verify=False,
                                      headers={"vmware-api-session-id": self.session_id})
@@ -66,7 +65,7 @@ class Connection:
     def logout(self):
         disable_warnings(exceptions.InsecureRequestWarning)
         LOG.debug(f"Logout {self.target} {self.session_id}")
-        url = "https://" + self.target + "/rest/com/vmware/cis/session"
+        url = f"https://{self.target}/rest/com/vmware/cis/session"
         try:
             response = requests.delete(url, verify=False,
                                        headers={"vmware-api-session-id": self.session_id})

--- a/modules/Vcenter.py
+++ b/modules/Vcenter.py
@@ -1,6 +1,7 @@
 import json
 import master_password
 
+
 class Vcenter:
     def __init__(self, atlasfile, mpw, user, password=None):
         self.vcenter_list = list()

--- a/modules/Vcenter.py
+++ b/modules/Vcenter.py
@@ -1,27 +1,28 @@
+from modules.Connection import Connection
 import json
 import master_password
 
 
 class Vcenter:
-    def __init__(self, atlasfile, mpw, user, password=None):
-        self.vcenter_list = list()
-        self.vc_pws = dict()
-        self.atlasfile = atlasfile
+    def __init__(self, name, atlasfile, mpw, user, password=None):
         self.user = user
         self.mpw = mpw
         self.pw = password
         if not password:
             self.pw_handle = self.generate_pw_handle()
+        self.session_id = None
+        self.name = name
 
-    def get_vcs_from_atlas(self):
-        with open(self.atlasfile) as json_file:
+    @staticmethod
+    def get_vcs_from_atlas(atlasfile):
+        with open(atlasfile) as json_file:
             netbox_json = json.load(json_file)
         vcenter_list = list()
         for target in netbox_json:
             if target['labels']['job'] == "vcenter":
                 vcenter = target['labels']['server_name']
                 vcenter_list.append(vcenter)
-        self.vcenter_list = vcenter_list
+        return vcenter_list
 
     def generate_pw_handle(self):
         return master_password.MPW(self.user, self.mpw)
@@ -30,3 +31,10 @@ class Vcenter:
         if self.pw:
             return self.pw
         return self.pw_handle.password(url)
+
+    def login(self):
+        self.session_id = Connection.login(self.name, self.user, self.generate_pw(self.name))
+
+    def logout(self):
+        if self.session_id:
+            Connection.logout(self.name, self.session_id)

--- a/modules/Vcenter.py
+++ b/modules/Vcenter.py
@@ -4,13 +4,13 @@ import master_password
 
 
 class Vcenter:
-    def __init__(self, name, mpw, user, password=None):
+    def __init__(self, name, mpw, user, password):
         self.user = user
         self.mpw = mpw
         self.pw = password
         if not password:
             self.pw_handle = self.generate_pw_handle()
-        self.session_id = None
+            self.pw = self.generate_pw(name)
         self.name = name
 
     @staticmethod
@@ -33,8 +33,9 @@ class Vcenter:
         return self.pw_handle.password(url)
 
     def login(self):
-        self.session_id = Connection.login(self.name, self.user, self.generate_pw(self.name))
+        self.con = Connection(self)
+        self.con.login()
 
     def logout(self):
-        if self.session_id:
-            Connection.logout(self.name, self.session_id)
+        if self.con.session_id:
+            self.con.logout()

--- a/modules/Vcenter.py
+++ b/modules/Vcenter.py
@@ -4,7 +4,7 @@ import master_password
 
 
 class Vcenter:
-    def __init__(self, name, atlasfile, mpw, user, password=None):
+    def __init__(self, name, mpw, user, password=None):
         self.user = user
         self.mpw = mpw
         self.pw = password

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ prometheus_client
 requests
 pyyaml
 master_password
+cryptography


### PR DESCRIPTION
cryptography dependency was missing
central thread generation in BaseCollector for all collectors, queries are in parallel now
changed Vcenter object to eventually reflect a vCenter, not all at once, like it was before
idea was to centralize login logout too, this is not working if triggered from  BaseCollector and would need some more implementation
Connection object is now passed through all objects as requested.