### PR TITLE
Fixing run_prometheus_server method [used global variable instead of …

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -44,10 +44,10 @@ def parse_params(logger):
     return options
 
 
-def run_prometheus_server(port, vcenter):
+def run_prometheus_server(port, vcenters):
     start_http_server(int(port))
-    REGISTRY.register(VmonCollector(all_vcenters))
-    REGISTRY.register(LoggingCollector(all_vcenters))
+    REGISTRY.register(VmonCollector(vcenters))
+    REGISTRY.register(LoggingCollector(vcenters))
     while True:
         time.sleep(1)
 


### PR DESCRIPTION
The run_prometheus_server method used the global variable "all_vcenters" instead of the parameter vcenter. The parameter vcenter gets renamed to "vcenters"